### PR TITLE
Switch the althea-packages repo entry from SSH to HTTPS

### DIFF
--- a/roles/prepare-config/defaults/main.yml
+++ b/roles/prepare-config/defaults/main.yml
@@ -1,4 +1,4 @@
 source_dir: build/
 feeds_list:
-  - "src-git althea git@github.com:althea-mesh/althea-packages.git"
+  - "src-git althea https://github.com/althea-mesh/althea-packages.git"
 conf_to_build: n600


### PR DESCRIPTION
This PR fixes the issue I've observed with blocked GitHub access over SSH from behind a corporate network. Also, all other items from the feeds list in `build/` use HTTPS.