### PR TITLE
Add althea-rust-binaries to target configs

### DIFF
--- a/config/n600
+++ b/config/n600
@@ -23,6 +23,7 @@ CONFIG_OPENSSL_WITH_PSK=y
 CONFIG_OPENSSL_WITH_SRP=y
 CONFIG_PACKAGE_adblock=y
 CONFIG_PACKAGE_althea-babeld=y
+CONFIG_PACKAGE_althea-rust-binaries=y
 CONFIG_PACKAGE_generate-ipv6-address=y
 CONFIG_PACKAGE_ar=m
 CONFIG_PACKAGE_babel-pinger=m

--- a/config/n750
+++ b/config/n750
@@ -23,6 +23,7 @@ CONFIG_OPENSSL_WITH_PSK=y
 CONFIG_OPENSSL_WITH_SRP=y
 CONFIG_PACKAGE_adblock=y
 CONFIG_PACKAGE_althea-babeld=y
+CONFIG_PACKAGE_althea-rust-binaries=y
 CONFIG_PACKAGE_generate-ipv6-address=y
 CONFIG_PACKAGE_ar=m
 CONFIG_PACKAGE_babel-pinger=m

--- a/config/virtualbox
+++ b/config/virtualbox
@@ -23,6 +23,7 @@ CONFIG_OPENSSL_WITH_SRP=y
 CONFIG_PACKAGE_ar=m
 CONFIG_PACKAGE_babel-pinger=m
 CONFIG_PACKAGE_althea-babeld=y
+CONFIG_PACKAGE_althea-rust-binaries=y
 CONFIG_PACKAGE_generate-ipv6-address=y
 CONFIG_PACKAGE_python-base=y
 CONFIG_PACKAGE_python-light=y


### PR DESCRIPTION
This PR adds the `althea_rs` package to each target's config. 