### PR TITLE
Update with arm targets

### DIFF
--- a/roles/check-deps/defaults/main.yml
+++ b/roles/check-deps/defaults/main.yml
@@ -138,4 +138,13 @@ rust_targets:
   - mipsel-unknown-linux-musl
   - x86_64-unknown-linux-gnu
   - x86_64-unknown-linux-musl
+  - arm-unknown-linux-gnueabi
+  - arm-unknown-linux-gnueabihf
+  - arm-unknown-linux-musleabi
+  - arm-unknown-linux-musleabihf
+  - armv5te-unknown-linux-gnueabi
+  - armv7-unknown-cloudabi-eabihf
+  - armv7-unknown-linux-gnueabihf
+  - armv7-unknown-linux-musleabihf
+
 


### PR DESCRIPTION
I didn't add these when I first made this because I wasn't sure what
was up with the prefixes. After some research by drozdziak it seems
that they are just aliases for arch details.

I think this list now contains all the arches we may need for openwrt
devices. Its possible to get a power or spark router but I very much
doubt it.