### PR TITLE
Increase the max-rtt-penalty to 2000

### DIFF
--- a/roles/build-config/templates/babeld.j2
+++ b/roles/build-config/templates/babeld.j2
@@ -14,7 +14,7 @@ config general
 ## default per-interface options
 config interface
         option 'enable_timestamps' 'true'
-        option 'max_rtt_penalty' '1000'
+        option 'max_rtt_penalty' '2000'
 
 config interface
         option 'ifname' 'fake_interface'


### PR DESCRIPTION
This makes babel metric more reliant on latency, allowing exit switcher in rita to make better decisions